### PR TITLE
functionality to sort commit timestamps language-wise

### DIFF
--- a/devprofiler/Cargo.toml
+++ b/devprofiler/Cargo.toml
@@ -6,17 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.0", features = ["derive"] }
-anyhow = "1.0"
-glob = "0.3.0"
-walkdir = "2"
-crossbeam-channel = "0.5.6"
 git2 = "0.15"
-time = "0.1"
-
-[dev-dependencies]
-criterion = "0.3"
-
-[[bench]]
-name = "my_benchmark"
-harness = false
+openssl = { version = "0.10", features = ["vendored"] }

--- a/devprofiler/Cargo.toml
+++ b/devprofiler/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 git2 = "0.15"
 openssl = { version = "0.10", features = ["vendored"] }
+detect-lang = "0.1.5"

--- a/devprofiler/src/main.rs
+++ b/devprofiler/src/main.rs
@@ -1,13 +1,14 @@
 #![allow(unused)]
 
+use core::time;
+use std::hash::Hash;
 // use clap::Parser;
 // use anyhow::{Context, Result};
 // use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::fs;
-// use time;
 use git2::{Commit, ObjectType, Repository, Diff, Tree, Error, Oid};
-use detect_lang::from_path;
+use detect_lang::{from_path, Language};
 use std::collections::HashMap;
 /// Search for a pattern in a file and display the lines that contain it.
 // #[derive(Parser)]
@@ -23,30 +24,35 @@ fn print_type_of<T>(_: &T) {
     println!("{}", std::any::type_name::<T>());
 }
 
-fn sort_commit_language_wise(repo: &Repository, author_name: &str, mut count: i32, commit: &Commit) -> i32 {
-	// let message = commit.summary_bytes().unwrap_or_else(|| commit.message_bytes());
-	let commit_timesatmp = commit.time();
+fn sort_commit_language_wise(repo: &Repository, commit: &Commit, parent_commit: &Commit, mut language_wise_commits: HashMap<String, Vec<String>>) -> HashMap<String, Vec<String>> {
 	let commit_tree = commit.tree().unwrap();
-	let author = commit.author();
-	if author.to_string().contains(author_name) {
-		// println!("{}\t{}\t{}", commit.id(), author, String::from_utf8_lossy(message));
-		let parent_commit = commit.parent(0).unwrap();
-		let parent_tree = parent_commit.tree().unwrap();
+	let parent_tree = parent_commit.tree().unwrap();
+	let mut commit_language_list: Vec<&str> = Vec::new();
 
-		let language_list: Vec<&str> = Vec::new();
-
-		let diff = repo.diff_tree_to_tree(Some(&commit_tree), Some(&parent_tree), None).unwrap();
-		for delta in diff.deltas() {
-			// println!("{:?}", delta.new_file().path().unwrap());
-			let detected_language = detect_lang::from_path(delta.new_file().path().unwrap());
-			println!("{:?}", detected_language);
-			// if language_list.contains()
-
+	let diff = repo.diff_tree_to_tree(Some(&commit_tree), Some(&parent_tree), None).unwrap();
+	for delta in diff.deltas() {
+		let detected_language = detect_lang::from_path(delta.new_file().path().unwrap());
+		match detected_language {
+			Some(Language(name, extension)) => {
+				if !commit_language_list.contains(&name){
+					commit_language_list.push(name);
+				}
+			}
+			None => {
+				// Handle the case where the option is None
+			}
 		}
-		count = count + 1;
-
 	}
-	return count;
+	for language in commit_language_list {
+		if language_wise_commits.contains_key(language) {
+			let commit_timestamps = language_wise_commits.get_mut(language).unwrap();
+			commit_timestamps.push(commit.time().seconds().to_string());
+		} else {
+			language_wise_commits.insert(language.to_string(), vec![commit.time().seconds().to_string()]);
+		}
+	}
+
+	return language_wise_commits;
 
 }
 
@@ -57,17 +63,22 @@ fn sort_commit_language_wise(repo: &Repository, author_name: &str, mut count: i3
 fn some_commit() -> Result<i32, Box<git2::Error>> {
     let repo = Repository::discover("/home/muskanp/mentorship-website").expect("error occured");
 	let mut revwalk = repo.revwalk().expect("revwalk failed");
-	revwalk.push_head().expect("push head failed");
-	revwalk.set_sorting(git2::Sort::TIME).expect("sorting failed");
 	let mut author_name = "muskan";
 	let mut count = 0;
+	let mut language_wise_commits: HashMap<String, Vec<String>> = HashMap::new();
+	
+	revwalk.push_head().expect("push head failed");
+	revwalk.set_sorting(git2::Sort::TIME).expect("sorting failed");
 
 	for rev in revwalk {
 
 		let commit = repo.find_commit(rev?)?;
-		count = sort_commit_language_wise(&repo, author_name, count, &commit);
+		let author = commit.author();
+		if author.to_string().contains(author_name) {
+			let parent_commit = commit.parent(0).unwrap(); //We are only passing the recent parent of a commit, but we will have to do it for all the parents of a commit.
+			language_wise_commits = sort_commit_language_wise(&repo, &commit, &parent_commit, language_wise_commits);
+		}	
 	}
-	println!("Number of commits: {}", count);
 	Ok(0)
     // let repo = match Repository::open("/Users/tapishpersonal/Code/mentorship-website") {
     //     Ok(repo) => repo,


### PR DESCRIPTION
- Created a function to traverse all the commits, find the diff between a commit and its recent parent, and get all the changed file's paths.
- Used `detect_lang` library to detect languages used in each commits.
- Returned a `HashMap` with `language` as keys and a list of `commit_timestamps` associated with the language as value.